### PR TITLE
Upgrades doctrine/orm version requirement to ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "symfony/uid": "^5.4 || ^6.0 || ^7.0",
     "symfony/twig-bundle": "^5.4 || ^6.0 || ^7.0",
     "doctrine/doctrine-bundle": "^2.0",
-    "doctrine/orm": "^3.0"
+    "doctrine/orm": "^2.6 || ^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "symfony/uid": "^5.4 || ^6.0 || ^7.0",
     "symfony/twig-bundle": "^5.4 || ^6.0 || ^7.0",
     "doctrine/doctrine-bundle": "^2.0",
-    "doctrine/orm": "^2.6"
+    "doctrine/orm": "^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
### Description

This pull request updates the package dependency to Doctrine ^3.0, which is necessary for the Symfony 7.2 compatibility update to work correctly. Without this change, the bundle **ranky/mendia-bundle** will no works properly with Symfony 7.2.

### Changes:

- Updated Doctrine dependency to version ^3.0

These changes are essential for maintaining compatibility with Symfony 7.2 and ensuring the bundle works as expected with the latest Doctrine version.